### PR TITLE
Ensure that GNUMake is used.

### DIFF
--- a/c_src/build_stats.sh
+++ b/c_src/build_stats.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+MAKE=$( which gmake ) || MAKE=make
+
 cd c_src
 if [ ! -d stats ]; then
     git clone --recursive https://github.com/kthohr/stats
@@ -8,4 +10,4 @@ fi
 # pinned to 2.2.0 commit, no tag
 (cd stats ; git reset --hard 659b1d9af2208de32fa17bcee9e4f3b0c5063a22)
 
-make
+${MAKE}


### PR DESCRIPTION
The Makefile for this project uses GNU Make syntax, but not all systems have GNU Make installed as
the default "make". If a system has "gmake" installed, that is likely the best choice. If "gmake" doesn't
exist, then it's safe to assume that the system make is GNU make.